### PR TITLE
Issue 58

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 grammar DMLStatement;
 
 import BaseRule;
@@ -165,7 +182,7 @@ limitOffset
     ;
 
 subquery
-    : LP_ combineClause RP_
+    : LP_ (withClause? combineClause) RP_
     ;
 
 withClause

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -1,23 +1,13 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 grammar DMLStatement;
 
 import BaseRule;
+
+dmlStatement
+    : insert
+    | update
+    | delete
+    | select
+    ;
 
 insert
     : INSERT INTO? tableName (insertValuesClause | insertSelectClause)
@@ -65,7 +55,7 @@ singleTableClause
     ;
 
 select
-    : combineClause
+    : withClause? combineClause
     ;
 
 combineClause
@@ -113,7 +103,7 @@ tableReferences
     ;
 
 escapedTableReference
-    : tableReference  | LBE_ tableReference RBE_
+    : tableReference | LBE_ tableReference RBE_
     ;
 
 tableReference
@@ -169,11 +159,19 @@ fetchClause
 limitRowCount
     : numberLiterals | parameterMarker
     ;
-    
+
 limitOffset
     : numberLiterals | parameterMarker
     ;
 
 subquery
     : LP_ combineClause RP_
+    ;
+
+withClause
+    : WITH RECURSIVE? cteClause (COMMA_ cteClause)*
+    ;
+
+cteClause
+    : identifier (LP_ columnNames RP_)? AS subquery
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -703,6 +703,15 @@ INVOKER
     : I N V O K E R
     ;
 
+RECURSIVE
+    : R E C U R S I V E
+    ;
+
+ROW
+    : R O W
+    ;
+
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;


### PR DESCRIPTION
Fixes #58

Changes proposed in this pull request:
  - Fix error message: "You have an error in your SQL syntax: SELECT C.CUST_NAME C.CUST_CITY FROM CUSTOMER c WHERE c.agent_code IN (WITH T121 AS (SELECT AGENT_CODE FROM AGENTS) SELECT C.CUST_NAME FROM CUSTOMER c LEFT JOIN T121 T ON T.AGENT_CODE = C.AGENT_CODE) no viable alternative at input 'IN' at line 1 position 68 near @1568:69='IN'<106>1:68"
  - New error message: "Table or view `T121` does not exist."
---

