### PR TITLE
FIX E161, T351

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -73,7 +73,7 @@ combineClause
     ;
 
 selectClause
-    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause?
+    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? (INLINE_COMMENT* | limitClause)?
     ;
 
 


### PR DESCRIPTION
Fixes #54, #61.

 - Проверил вывод, комментарии теперь скипаются.

1. Запрос: SELECT Cust_code FROM Customer --Comments from query
Ошибка:  You have an error in your SQL syntax: SELECT Cust_code FROM Customer --Comments from query no viable alternative at input '--' at line 1 position 32 near @432:33='--'<41>1:32
<details>
  <summary>Пример вывода со скипом комментариев для проверки 1 запрос</summary>
(select (combineClause (selectClause SELECT (projections (projection (columnName (name (identifier Cust_code))))) (fromClause FROM (tableReferences (escapedTableReference (tableReference (tableFactor (tableName (name (identifier Customer)))))))))))
</details>

2. Запрос: SELECT AGENT_NAME FROM agents /*Bracketed SQL comments*/ WHERE AGENT_NAME like '%u%'
Ошибка:You have an error in your SQL syntax: SELECT AGENT_NAME FROM agents /*Bracketed SQL comments*/ WHERE AGENT_NAME like '%u%' no viable alternative at input '/' at line 1 position 31 near @431:31='/'<16>1:31
<details>
  <summary>Пример вывода со скипом комментариев для проверки 2 запрос</summary>
(select (combineClause (selectClause SELECT (projections (projection (columnName (name (identifier AGENT_NAME))))) (fromClause FROM (tableReferences (escapedTableReference (tableReference (tableFactor (tableName (name (identifier agents)))))))))))
</details>



---
