### PR TITLE
T175 Generated columns

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -300,7 +300,7 @@ orderByItem
     ;
 
 dataType
-    : dataTypeName dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
+    : dataTypeName? generatedOption? dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
     ;
 
 dataTypeName
@@ -312,6 +312,10 @@ dataTypeName
 
 dataTypeLength
     : LP_ NUMBER_ (COMMA_ NUMBER_)? RP_
+    ;
+
+generatedOption
+    : GENERATED ALWAYS AS LP_ expr RP_
     ;
 
 characterSet

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -711,6 +711,13 @@ ROW
     : R O W
     ;
 
+GENERATED
+    : G E N E R A T E D
+    ;
+
+ALWAYS
+    : A L W A Y S
+    ;
 
 //PASSWORD
 //    : P A S S W O R D


### PR DESCRIPTION
Fixes #59.

Запрос: CREATE TABLE T175 (row_a int, row_b generated always as (3*row_a))
Ошибка:You have an error in your SQL syntax: CREATE TABLE T175 (row_a int row_b generated always as (3*row_a)) null

Новая ошибка: Cannot invoke "org.antlr.v4.runtime.tree.ParseTree.accept(org.antlr.v4.runtime.tree.ParseTreeVisitor)" because "tree" is null

---
