### PR TITLE
T615/T617 WINDOW FUNCTION

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -100,6 +100,10 @@ columnName
     : (owner DOT_)? name
     ;
 
+windowName
+    : name
+    ;
+
 viewName
     : identifier
     | (owner DOT_)? identifier
@@ -328,4 +332,11 @@ ignoredIdentifier
 
 dropBehaviour
     : (CASCADE | RESTRICT)?
+    ;
+
+windowFunction
+    : (ROW_NUMBER | RANK | DENSE_RANK ) LP_ (expr (COMMA_ expr)*)? RP_
+    | (LEAD | LAG) LP_ (expr (COMMA_ expr)*)? RP_
+    | (FIRST_VALUE | LAST_VALUE) LP_ (expr (COMMA_ expr)*)? RP_
+    | NTH_VALUE LP_ (expr (COMMA_ expr)*)? RP_
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -73,30 +73,13 @@ combineClause
     ;
 
 selectClause
-    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause? overClause? // windowClause?
+    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause? overClause?
     ;
 
 overClause
     : windowFunction? OVER LP_ partitionClause? sortClause? RP_
     ;
 
-//windowClause
-//    : WINDOW windowDefinitionList
-//    ;
-//
-//windowDefinitionList
-//    : windowDefinition
-//    | windowDefinitionList COMMA_ windowDefinition
-//    ;
-//
-//windowDefinition
-//    : colId AS windowSpecification
-//    ;
-//
-//windowSpecification
-//    : LP_ windowName? partitionClause? sortClause? RP_
-//    ;
-//
 partitionClause
     : PARTITION BY expr (COMMA_ expr)*
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -73,9 +73,53 @@ combineClause
     ;
 
 selectClause
-    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause?
+    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause? overClause? // windowClause?
     ;
 
+overClause
+    : windowFunction? OVER LP_ partitionClause? sortClause? RP_
+    ;
+
+//windowClause
+//    : WINDOW windowDefinitionList
+//    ;
+//
+//windowDefinitionList
+//    : windowDefinition
+//    | windowDefinitionList COMMA_ windowDefinition
+//    ;
+//
+//windowDefinition
+//    : colId AS windowSpecification
+//    ;
+//
+//windowSpecification
+//    : LP_ windowName? partitionClause? sortClause? RP_
+//    ;
+//
+partitionClause
+    : PARTITION BY expr (COMMA_ expr)*
+    ;
+
+sortClause
+    : ORDER BY sortbyList
+    ;
+
+sortbyList
+    : sortby (COMMA_ sortby)*
+    ;
+
+sortby
+    : expr ascDesc? nullsOrder?
+    ;
+
+nullsOrder
+    : NULLS (FIRST | LAST)
+    ;
+
+ascDesc
+    : ASC | DESC
+    ;
 
 selectSpecification
     : duplicateSpecification
@@ -90,7 +134,7 @@ projections
     ;
 
 projection
-    : (columnName | expr) (AS? alias)? | qualifiedShorthand
+    : (overClause | columnName | expr) (AS? alias)? | qualifiedShorthand
     ;
 
 alias

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -711,6 +711,54 @@ ROW
     : R O W
     ;
 
+ROLE
+    : R O L E
+    ;
+
+RANK
+    : R A N K
+    ;
+
+ROW_NUMBER
+    : R O W UL_ N U M B  E R
+    ;
+
+DENSE_RANK
+    : D E N S E UL_ R A N K
+    ;
+
+LEAD
+    : L E A D
+    ;
+
+LAG
+    : L A G
+    ;
+
+FIRST_VALUE
+    : F I R S T UL_ V A L U E
+    ;
+
+LAST_VALUE
+    : L A S T UL_ V A L U E
+    ;
+
+NTH_VALUE
+    : N T H UL_ V A L U E
+    ;
+
+OVER
+    : O V E R
+    ;
+
+PARTITION
+    : P A R T I T I O N
+    ;
+
+NULLS
+    : N U L L S
+    ;
+
 
 //PASSWORD
 //    : P A S S W O R D


### PR DESCRIPTION
Fixes #62, #63.

- Запрос: SELECT CUST_CODE, CUST_NAME, rank() over (order by opening_amt), lead(opening_amt,1) over (order by opening_amt) FROM CUSTOMER order by opening_amt

Ошибка: You have an error in your SQL syntax: SELECT CUST_CODE CUST_NAME rank() over (order by opening_amt) lead(opening_amt1) over (order by opening_amt) FROM CUSTOMER order by opening_amt no viable alternative at input '(' at line 1 position 42 near @942:42='('<29>1:42
- Запрос: SELECT CUST_CODE, CUST_NAME, rank() over (order by opening_amt), first_value (opening_amt) over (order by opening_amt) FROM CUSTOMER order by opening_amt

Ошибка: You have an error in your SQL syntax: SELECT CUST_CODE CUST_NAME rank() over (order by opening_amt) first_value (opening_amt) over (order by opening_amt) FROM CUSTOMER order by opening_amt no viable alternative at input '(' at line 1 position 42 near @942:42='('<29>1:42

Новая ошибка:  Cannot invoke "org.antlr.v4.runtime.tree.ParseTree.accept(org.antlr.v4.runtime.tree.ParseTreeVisitor)" because "tree" is null
