### PR TITLE
Add T271 Savepoints support

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -92,6 +92,10 @@ schemaName
     : identifier
     ;
 
+savepointName
+    : identifier
+    ;
+
 tableName
     : (owner DOT_)? name
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/TCLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/TCLStatement.g4
@@ -36,5 +36,5 @@ levelOfIsolation
     ;
 
 savepoint
-    : SAVEPOINT name
+    : SAVEPOINT savepointName
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
@@ -36,5 +36,6 @@ execute
     | rollback
     | grant
     | revoke
+    | savepoint
     ) SEMI_?
     ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdTCLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdTCLStatementVisitor.java
@@ -22,10 +22,15 @@ import org.apache.shardingsphere.sql.parser.api.visitor.statement.type.TCLStatem
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CommitContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.RollbackContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.SetTransactionContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.SavepointContext;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl.FirebirdCommitStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl.FirebirdRollbackStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl.FirebirdSetTransactionStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl.FirebirdSavepointStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
+
+
+
 
 /**
  * TCL statement visitor for Firebird.
@@ -45,5 +50,10 @@ public final class FirebirdTCLStatementVisitor extends FirebirdStatementVisitor 
     @Override
     public ASTNode visitRollback(final RollbackContext ctx) {
         return new FirebirdRollbackStatement();
+    }
+
+    @Override
+    public ASTNode visitSavepoint(final SavepointContext ctx) {
+        return new FirebirdSavepointStatement();
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/tcl/FirebirdSavepointStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/tcl/FirebirdSavepointStatement.java
@@ -15,26 +15,13 @@
  * limitations under the License.
  */
 
-grammar TCLStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl;
 
-import BaseRule;
-
-setTransaction
-    : SET TRANSACTION ISOLATION LEVEL levelOfIsolation
-    ;
-
-commit
-    : COMMIT
-    ;
-
-rollback
-    : ROLLBACK
-    ;
-
-levelOfIsolation
-    : READ UNCOMMITTED | READ COMMITTED | REPEATABLE READ| SERIALIZABLE
-    ;
-
-savepoint
-    : SAVEPOINT name
-    ;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.tcl.SavepointStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
+// org\apache\shardingsphere\sql\parser\sql\dialect\statement
+/**
+ * PostgreSQL savepoint statement.
+ */
+public final class FirebirdSavepointStatement extends SavepointStatement implements FirebirdStatement {
+}

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/tcl/FirebirdSavepointStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/tcl/FirebirdSavepointStatement.java
@@ -19,9 +19,10 @@ package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.tcl;
 
 import org.apache.shardingsphere.sql.parser.sql.common.statement.tcl.SavepointStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
-// org\apache\shardingsphere\sql\parser\sql\dialect\statement
+
 /**
- * PostgreSQL savepoint statement.
+ * Firebird savepoint statement.
  */
+
 public final class FirebirdSavepointStatement extends SavepointStatement implements FirebirdStatement {
 }


### PR DESCRIPTION
Fixes #45.

Запрос:  savepoint y
Ошибка: You have an error in your SQL syntax: savepoint y no viable alternative at input 'savepoint' at line 1 position 1 near @01:9='savepoint'<121>1:1

- Исправлен

