### PR TITLE
F251 FIX ( add CREATE DOMAIN support )

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -299,6 +299,13 @@ orderByItem
     : (columnName | numberLiterals) (ASC | DESC)?
     ;
 
+createDomainClause
+    : DEFAULT (literals | NULL | variable)?
+    | NOT NULL
+    | CHECK LP_ expr RP_
+    | CHARACTER SET  characterSetName (collateClause)?
+    ;
+
 dataType
     : dataTypeName dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -81,7 +81,7 @@ unreservedWord
     | REPEATABLE | RETURNED_LENGTH | RETURNED_OCTET_LENGTH | RETURNED_SQLSTATE | ROW_COUNT
     | SCALE | SCHEMA_NAME | SERIALIZABLE | SERVER_NAME | SUBCLASS_ORIGIN
     | TABLE_NAME | TYPE
-    | UNCOMMITTED | UNNAMED
+    | UNCOMMITTED | UNNAMED | VALUE
     ;
 
 variable
@@ -166,6 +166,7 @@ predicate
     | bitExpr NOT? IN LP_ expr (COMMA_ expr)* RP_
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?
+    | bitExpr NOT? STARTING WITH? bitExpr
     | bitExpr
     ;
 
@@ -302,7 +303,7 @@ orderByItem
 createDomainClause
     : DEFAULT (literals | NULL | variable)?
     | NOT NULL
-    | CHECK LP_ expr RP_
+    | CHECK LP_ predicate RP_
     | CHARACTER SET  characterSetName (collateClause)?
     ;
 

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -92,6 +92,10 @@ schemaName
     : identifier
     ;
 
+domainName
+    : identifier
+    ;
+
 tableName
     : (owner DOT_)? name
     ;
@@ -300,13 +304,6 @@ orderByItem
     : (columnName | numberLiterals) (ASC | DESC)?
     ;
 
-createDomainClause
-    : DEFAULT (literals | NULL | variable)?
-    | NOT NULL
-    | CHECK LP_ predicate RP_
-    | CHARACTER SET  characterSetName (collateClause)?
-    ;
-
 dataType
     : dataTypeName dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
     ;
@@ -336,4 +333,18 @@ ignoredIdentifier
 
 dropBehaviour
     : (CASCADE | RESTRICT)?
+    ;
+
+defaultValue
+    : (literals | NULL | contextVariables)
+    ;
+
+contextVariables
+    : CURRENT_CONNECTION | CURRENT_DATE | CURRENT_ROLE
+    | CURRENT_TIME | CURRENT_TIMESTAMP
+    | CURRENT_TRANSACTION | CURRENT_USER
+    | INSERTING | UPDATING | DELETING
+    | NEW | NOW | OLD | ROW_COUNT
+    | SQLCODE | GDSCODE | SQLSTATE
+    | TODAY | TOMORROW | USER | YESTERDAY
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -23,6 +23,10 @@ createTable
     : CREATE createTemporaryTable? TABLE tableName createDefinitionClause sqlSecurity?
     ;
 
+createDomain
+    : CREATE DOMAIN name AS? dataType createDomainClause?
+    ;
+
 alterTable
     : ALTER TABLE tableName alterDefinitionClause
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -24,7 +24,23 @@ createTable
     ;
 
 createDomain
-    : CREATE DOMAIN name AS? dataType createDomainClause?
+    : CREATE DOMAIN domainName AS? dataType defaultClause? notNullClause? checkClause? characterSetClause?
+    ;
+
+defaultClause
+    : DEFAULT defaultValue?
+    ;
+
+notNullClause
+    : NOT NULL
+    ;
+
+checkClause
+    : CHECK predicate
+    ;
+
+characterSetClause
+    : CHARACTER SET characterSetName collateClause?
     ;
 
 alterTable

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -36,7 +36,7 @@ notNullClause
     ;
 
 checkClause
-    : CHECK predicate
+    : CHECK LP_ predicate RP_
     ;
 
 characterSetClause

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -711,6 +711,9 @@ ROW
     : R O W
     ;
 
+STARTING
+    : S T A R T I N G
+    ;
 
 //PASSWORD
 //    : P A S S W O R D

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -35,6 +35,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Drop
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.DropConstraintSpecificationContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.DropTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ModifyColumnSpecificationContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateDomainContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
@@ -53,6 +54,7 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.Identifi
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateDomainStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
 import java.util.Collections;
@@ -214,5 +216,10 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
         FirebirdDropTableStatement result = new FirebirdDropTableStatement();
         result.getTables().addAll(((CollectionValue<SimpleTableSegment>) visit(ctx.tableNames())).getValue());
         return result;
+    }
+
+    @Override
+    public ASTNode visitCreateDomain(final CreateDomainContext ctx) {
+        return new FirebirdCreateDomainStatement();
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCreateDomainStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCreateDomainStatement.java
@@ -15,27 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateDomainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createDomain
-    ) SEMI_?
-    ;
+/**
+ * Firebird create domain statement.
+ */
+public final class FirebirdCreateDomainStatement extends CreateDomainStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #27.

***request:*** CREATE DOMAIN PONUMBER AS CHAR(8) CHARACTER SET NONE CHECK (VALUE STARTING WITH 'V') COLLATE NONE
***err mess:*** You have an error in your SQL syntax: CREATE DOMAIN PONUMBER AS CHAR(8) CHARACTER SET NONE CHECK (VALUE STARTING WITH 'V') COLLATE NONE no viable alternative at input 'CREATEDOMAIN' at line 1 position 8 near @18:13='DOMAIN'<257>1:8

~~***new err mess:*** You have an error in your SQL syntax: CREATE DOMAIN PONUMBER AS CHAR(8) CHARACTER SET NONE CHECK (VALUE STARTING WITH 'V') COLLATE NONE no viable alternative at input 'VALUE' at line 1 position 61 near @1361:65='VALUE'<335>1:61~~

