### PR TITLE
T617/T615 FIX (add overclause and Win func)

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -207,7 +207,7 @@ functionCall
     ;
 
 aggregationFunction
-    : aggregationFunctionName LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? RP_
+    : aggregationFunctionName LP_ distinct? (expr (COMMA_ expr)* | ASTERISK_)? RP_ overClause?
     ;
 
 aggregationFunctionName
@@ -219,7 +219,13 @@ distinct
     ;
 
 specialFunction
-    : castFunction | convertFunction | positionFunction | substringFunction | extractFunction | trimFunction
+    : castFunction
+    | convertFunction
+    | positionFunction
+    | substringFunction
+    | extractFunction
+    | trimFunction
+    | windowFunction
     ;
 
 castFunction
@@ -328,4 +334,13 @@ ignoredIdentifier
 
 dropBehaviour
     : (CASCADE | RESTRICT)?
+    ;
+
+windowFunction
+    : funcName = (ROW_NUMBER | RANK | DENSE_RANK) LP_ (expr (COMMA_ expr)* | ASTERISK_)? RP_ overClause?
+    | funcName = (LEAD | LAG | FIRST_VALUE | LAST_VALUE | NTH_VALUE) LP_ (expr (COMMA_ expr)* | ASTERISK_)? RP_ overClause?
+    ;
+
+overClause
+    : OVER LP_ (PARTITION BY expr (COMMA_ expr)*)? orderByClause? RP_
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -711,6 +711,46 @@ ROW
     : R O W
     ;
 
+ROW_NUMBER
+    : R O W UL_ N U M B E R
+    ;
+
+RANK
+    : R A N K
+    ;
+
+DENSE_RANK
+    : D E N S E UL_ R A N K
+    ;
+
+LEAD
+    : L E A D
+    ;
+
+LAG
+    : L A G
+    ;
+
+FIRST_VALUE
+    : F I R S T UL_ V A L U E
+    ;
+
+LAST_VALUE
+    : L A S T UL_ V A L U E
+    ;
+
+NTH_VALUE
+    : N T H UL_ V A L U E
+    ;
+
+PARTITION
+    : P A R T I T I O N
+    ;
+
+OVER
+    : O V E R
+    ;
+
 
 //PASSWORD
 //    : P A S S W O R D


### PR DESCRIPTION
Fixes #63, #64.

request: SELECT CUST_CODE, CUST_NAME, rank() over (order by opening_amt), first_value (opening_amt) over (order by opening_amt) FROM CUSTOMER order by opening_amt
err message:You have an error in your SQL syntax: SELECT CUST_CODE CUST_NAME rank() over (order by opening_amt) first_value (opening_amt) over (order by opening_amt) FROM CUSTOMER order by opening_amt no viable alternative at input '(' at line 1 position 42 near @942:42='('<29>1:42

request:SELECT CUST_CODE, CUST_NAME, row_number() over (order by opening_amt) FROM CUSTOMER order by opening_amt
Err message:You have an error in your SQL syntax: SELECT CUST_CODE CUST_NAME row_number() over (order by opening_amt) FROM CUSTOMER order by opening_amt no viable alternative at input '(' at line 1 position 48 near @948:48='('<29>1:48

Add overclause support and fix winfuction

---
