### PR TITLE
E121_FIX

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -125,7 +125,7 @@ functionName
     : identifier
     ;
 
-domainName
+triggerName
     : identifier
     ;
 

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -121,7 +121,6 @@ createFunction
       )
     ;
 
-
 statementBlock
     : (statement SEMI_)*
     ;
@@ -349,24 +348,39 @@ createProcedure
         )
     ;
 
+createTrigger
+    : CREATE TRIGGER triggerName triggerClause
+    ;
+
+alterTrigger
+    : ALTER TRIGGER triggerName (ACTIVE | INACTIVE)? ((BEFORE | AFTER) eventListTable)? (POSITION expr)? triggerClause
+    ;
+
 createOrAlterTrigger
-    : CREATE OR ALTER TRIGGER triggerName
-    (
-    announcmentTableTrigger |
-    announcmentTableTriggerSQL_2003Standart |
-    announcmentDataBaseTrigger |
-    announcmentDDLTrigger
-    )
-    (
-          EXTERNAL NAME externalModuleName ENGINE engineName
-      |
-          (SQL SECURITY (DEFINER | INVOKER))?
-          AS
-          announcementClause?
-          BEGIN
-              statementBlock
-          END
-    )
+    : CREATE OR ALTER TRIGGER triggerName triggerClause
+    ;
+
+announcmentTriggerClause
+    : (
+                announcmentTableTrigger |
+                announcmentTableTriggerSQL_2003Standart |
+                announcmentDataBaseTrigger |
+                announcmentDDLTrigger
+                )
+    ;
+
+triggerClause
+    : announcmentTriggerClause?
+          (
+                EXTERNAL NAME externalModuleName ENGINE engineName
+            |
+                (SQL SECURITY (DEFINER | INVOKER) | DROP SQL SECURITY)?
+                AS
+                announcementClause?
+                BEGIN
+                    statementBlock
+                END
+          )
     ;
 
 announcmentTableTrigger

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -76,14 +76,14 @@ alterSequence
     ;
 
 alterDomain
-    : ALTER DOMAIN domainName toTableClause? defaultClause? notNullAlterDomainClause? constraintClause? typeClause?
+    : ALTER DOMAIN domainName toTableClause? defaultAlterDomainClause? notNullAlterDomainClause? constraintClause? typeClause?
     ;
 
 toTableClause
     : TO tableName
     ;
 
-defaultClause
+defaultAlterDomainClause
     : (SET DEFAULT defaultValue | DROP DEFAULT)
     ;
 
@@ -133,10 +133,15 @@ statement
     | delete
     | returnStatement
     | cursorOpenStatement
+    | cursorCloseStatement
     ;
 
 cursorOpenStatement
     : OPEN cursorName
+    ;
+
+cursorCloseStatement
+    : CLOSE cursorName
     ;
 
 announcementClause
@@ -342,4 +347,90 @@ createProcedure
                 statementBlock
             END
         )
+    ;
+
+createOrAlterTrigger
+    : CREATE OR ALTER TRIGGER triggerName
+    (
+    announcmentTableTrigger |
+    announcmentTableTriggerSQL_2003Standart |
+    announcmentDataBaseTrigger |
+    announcmentDDLTrigger
+    )
+    (
+          EXTERNAL NAME externalModuleName ENGINE engineName
+      |
+          (SQL SECURITY (DEFINER | INVOKER))?
+          AS
+          announcementClause?
+          BEGIN
+              statementBlock
+          END
+    )
+    ;
+
+announcmentTableTrigger
+    : FOR (tableName | viewName)
+    (ACTIVE | INACTIVE)?
+    (BEFORE | AFTER) eventListTable
+    (POSITION expr)?
+    ;
+
+eventListTable
+    : dmlStatement (OR dmlStatement)*
+    ;
+
+listDDLStatement
+    : ANY DDL STATEMENT
+    | ddlStatement (OR ddlStatement)*
+    ;
+
+dmlStatement
+    : INSERT | UPDATE | DELETE
+    ;
+
+ddlStatement
+    : (CREATE | ALTER | DROP) TABLE
+    | (CREATE | ALTER | DROP) PROCEDURE
+    | (CREATE | ALTER | DROP) FUNCTION
+    | (CREATE | ALTER | DROP) TRIGGER
+    | (CREATE | ALTER | DROP) EXCEPTION
+    | (CREATE | ALTER | DROP) VIEW
+    | (CREATE | ALTER | DROP) DOMAIN
+    | (CREATE | ALTER | DROP) ROLE
+    | (CREATE | ALTER | DROP) SEQUENCE
+    | (CREATE | ALTER | DROP) USER
+    | (CREATE|ALTER|DROP) INDEX
+    | (CREATE | DROP) COLLATION
+    | ALTER CHARACTER SET
+    | (CREATE | ALTER | DROP) PACKAGE
+    | (CREATE | DROP) PACKAGE BODY
+    | (CREATE | ALTER | DROP) MAPPING
+    ;
+
+announcmentTableTriggerSQL_2003Standart
+    : (ACTIVE | INACTIVE)?
+      (BEFORE | AFTER) eventListTable
+      (POSITION expr)?
+      ON (tableName | viewName)
+    ;
+
+announcmentDataBaseTrigger
+    : (ACTIVE | INACTIVE)?
+      ON eventConnectOrTransaction
+      (POSITION expr)?
+    ;
+
+eventConnectOrTransaction
+    : CONNECT
+    | DISCONNECT
+    | TRANSACTION START
+    | TRANSACTION COMMIT
+    | TRANSACTION ROLLBACK
+    ;
+
+announcmentDDLTrigger
+    : (ACTIVE | INACTIVE)?
+      (BEFORE | AFTER) listDDLStatement
+      (POSITION expr)?
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -136,7 +136,7 @@ joinSpecification
     ;
 
 whereClause
-    : WHERE expr
+    : WHERE (expr | CURRENT OF cursorName)
     ;
 
 groupByClause

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -855,6 +855,22 @@ STARTING
     : S T A R T I N G
     ;
 
+ACTIVE
+    : A C T I V E
+    ;
+
+INACTIVE
+    : I N A C T I V E
+    ;
+
+BEFORE
+    : B E F O R E
+    ;
+
+AFTER
+    : A F T E R
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
@@ -44,5 +44,6 @@ execute
     | alterDomain
     | createRole
     | savepoint
+    | createOrAlterTrigger
     ) SEMI_?
     ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Alte
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterSequenceContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterDomainContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterTriggerContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CheckConstraintDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ColumnDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ConstraintDefinitionContext;
@@ -41,6 +42,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Crea
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateProcedureContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateCollationContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateDomainContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateTriggerContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
@@ -58,13 +60,15 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.collection.Collecti
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterDomainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterSequenceStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateTableStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateProcedureStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterSequenceStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateCollationStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateDomainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
 import java.util.Collections;
@@ -262,5 +266,15 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
     @Override
     public ASTNode visitCreateDomain(final CreateDomainContext ctx) {
         return new FirebirdCreateDomainStatement();
+    }
+
+    @Override
+    public ASTNode visitAlterTrigger(final AlterTriggerContext ctx) {
+        return new FirebirdAlterTriggerStatement();
+    }
+
+    @Override
+    public ASTNode visitCreateTrigger(final CreateTriggerContext ctx) {
+        return new FirebirdCreateTriggerStatement();
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdAlterTriggerStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdAlterTriggerStatement.java
@@ -15,37 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createFunction
-    | createProcedure
-    | alterSequence
-    | createCollation
-    | createDomain
-    | alterDomain
-    | createRole
-    | savepoint
-    | createOrAlterTrigger
-    | createTrigger
-    | alterTrigger
-    ) SEMI_?
-    ;
+/**
+ * Firebird alter trigger statement.
+ */
+public final class FirebirdAlterTriggerStatement extends AlterTriggerStatement implements FirebirdStatement {
+}

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCreateTriggerStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCreateTriggerStatement.java
@@ -15,37 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CreateTriggerStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createFunction
-    | createProcedure
-    | alterSequence
-    | createCollation
-    | createDomain
-    | alterDomain
-    | createRole
-    | savepoint
-    | createOrAlterTrigger
-    | createTrigger
-    | alterTrigger
-    ) SEMI_?
-    ;
+/**
+ * Firebird create trigger statement.
+ */
+public final class FirebirdCreateTriggerStatement extends CreateTriggerStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #15.

***request:*** CREATE OR ALTER TRIGGER DECCURS1 before update on Company AS DECLARE cursor1 CURSOR for (select id, namecompany, typeproduct from company where typeproduct = 'pc'); BEGIN end
***error message:*** You have an error in your SQL syntax: CREATE OR ALTER TRIGGER DECCURS1 before update on Company AS DECLARE cursor1 CURSOR for (select id namecompany typeproduct from company where typeproduct = 'pc'); BEGIN end no viable alternative at input 'CREATEOR' at line 1 position 8 near @18:9='OR'<98>1:8

***new error message:***
 Can not accept SQL type `CreateOrAlterTriggerContext`.

