### PR TITLE
T321 Add CREATE OR ALTER PROCEDURE support 

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -218,7 +218,8 @@ comparisonOperator
     ;
 
 predicate
-    : bitExpr NOT? IN subquery
+    : bitExpr comparisonOperator bitExpr
+    | bitExpr NOT? IN subquery
     | bitExpr NOT? IN LP_ expr (COMMA_ expr)* RP_
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -92,6 +92,10 @@ schemaName
     : identifier
     ;
 
+variableName
+    : identifier
+    ;
+
 domainName
     : identifier
     ;
@@ -125,10 +129,6 @@ functionName
     : identifier
     ;
 
-domainName
-    : identifier
-    ;
-
 argumentName
     : identifier
     ;
@@ -158,7 +158,7 @@ constraintName
     ;
 
 externalModuleName
-    : identifier
+    : STRING_
     ;
 
 cursorName
@@ -196,7 +196,7 @@ expr
 andOperator
     : AND | AND_
     ;
-    
+
 orOperator
     : OR | CONCAT_
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -123,7 +123,7 @@ createFunction
 
 
 statementBlock
-    : (statement SEMI_)*
+    : (statement SEMI_?)*
     ;
 
 statement
@@ -133,12 +133,20 @@ statement
     | delete
     | returnStatement
     | cursorOpenStatement
+    | cursorCloseStatement
     | assignmentStatement
     | transferStatement
+    | fetchStatement
+    | whileStatement
+    | ifStatement
     ;
 
 cursorOpenStatement
     : OPEN cursorName
+    ;
+
+cursorCloseStatement
+    : CLOSE cursorName
     ;
 
 announcementClause
@@ -374,7 +382,41 @@ outputArgument
 assignmentStatement
     : variableName EQ_ expr
     ;
-    
+
 transferStatement
-    : SUSPEND
+    : SUSPEND SEMI_
+    ;
+
+whileStatement
+    : WHILE LP_ predicate RP_ DO compoundStatement
+    ;
+
+fetchStatement
+    : FETCH cursorName
+    INTO COLON_ variable (COMMA_ (COLON_ variable))* SEMI_
+    | FETCH (NEXT
+             | PRIOR
+             | FIRST
+             | LAST
+             | ABSOLUTE NUMBER_
+             | RELATIVE NUMBER_ ) FROM cursorName (INTO LBT_ COLON_ RBT_ variable (COMMA_ (LBT_ COLON_ RBT_ variable))* SEMI_)
+    ;
+
+ifStatement
+    :
+     IF LP_ predicate RP_
+     THEN compoundStatement+
+     (ELSE compoundStatement+)?
+    ;
+
+compoundStatement
+    : (createTable | alterTable | dropTable | dropDatabase | insert | update | delete | select | createView | beginStatement | ifStatement | fetchStatement | leaveStatement | transferStatement | cursorCloseStatement) SEMI_?
+    ;
+
+beginStatement
+    : BEGIN compoundStatement* END SEMI_?
+    ;
+
+leaveStatement
+    : LEAVE expr? SEMI_
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -76,14 +76,14 @@ alterSequence
     ;
 
 alterDomain
-    : ALTER DOMAIN domainName toTableClause? defaultClause? notNullAlterDomainClause? constraintClause? typeClause?
+    : ALTER DOMAIN domainName toTableClause? defaultAlterDomainClause? notNullAlterDomainClause? constraintClause? typeClause?
     ;
 
 toTableClause
     : TO tableName
     ;
 
-defaultClause
+defaultAlterDomainClause
     : (SET DEFAULT defaultValue | DROP DEFAULT)
     ;
 
@@ -133,6 +133,8 @@ statement
     | delete
     | returnStatement
     | cursorOpenStatement
+    | assignmentStatement
+    | transferStatement
     ;
 
 cursorOpenStatement
@@ -342,4 +344,37 @@ createProcedure
                 statementBlock
             END
         )
+    ;
+
+createOrAlterProcedure
+    : CREATE OR ALTER PROCEDURE procedureName
+      (AUTHID (OWNER | CALLER))?
+        inputArgumentClause?
+      (RETURNS LP_ outputArgumentClause RP_)?
+      (
+          EXTERNAL NAME externalModuleName ENGINE engineName
+      |
+          (SQL SECURITY (DEFINER | INVOKER))?
+          AS
+          announcementClause?
+          BEGIN
+              statementBlock
+          END
+      )
+    ;
+
+outputArgumentClause
+    : outputArgument (COMMA_ outputArgument)*
+    ;
+
+outputArgument
+    : announcementArgument
+    ;
+
+assignmentStatement
+    : variableName EQ_ expr
+    ;
+    
+transferStatement
+    : SUSPEND
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -339,36 +339,31 @@ returnStatement
     ;
 
 createProcedure
-    : CREATE PROCEDURE procedureName (AUTHID (OWNER | CALLER))?
-        inputArgumentClause?
-        (RETURNS announcementArgument)?
-        (
-            EXTERNAL NAME externalModuleName ENGINE engineName
-        |
-            (SQL SECURITY (DEFINER | INVOKER))?
-            AS
-            announcementClause?
-            BEGIN
-                statementBlock
-            END
-        )
+    : CREATE PROCEDURE procedureClause
     ;
 
 createOrAlterProcedure
-    : CREATE OR ALTER PROCEDURE procedureName
-      (AUTHID (OWNER | CALLER))?
-        inputArgumentClause?
-      (RETURNS LP_ outputArgumentClause RP_)?
-      (
-          EXTERNAL NAME externalModuleName ENGINE engineName
-      |
-          (SQL SECURITY (DEFINER | INVOKER))?
-          AS
-          announcementClause?
-          BEGIN
-              statementBlock
-          END
-      )
+    : CREATE OR ALTER PROCEDURE procedureClause
+    ;
+
+alterProcedure
+    : ALTER PROCEDURE procedureClause
+    ;
+
+procedureClause
+    : procedureName (AUTHID (OWNER | CALLER))?
+              inputArgumentClause?
+              (RETURNS LP_ outputArgumentClause RP_)?
+              (
+                  EXTERNAL NAME externalModuleName ENGINE engineName
+              |
+                  (SQL SECURITY (DEFINER | INVOKER))?
+                  AS
+                  announcementClause?
+                  BEGIN
+                      statementBlock
+                  END
+              )
     ;
 
 outputArgumentClause

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -855,6 +855,10 @@ STARTING
     : S T A R T I N G
     ;
 
+SUSPEND
+    : S U S P E N D
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -859,6 +859,14 @@ SUSPEND
     : S U S P E N D
     ;
 
+WHILE
+    : W H I L E
+    ;
+
+LEAVE
+    : L E A V E
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
@@ -44,5 +44,6 @@ execute
     | alterDomain
     | createRole
     | savepoint
+    | createOrAlterProcedure
     ) SEMI_?
     ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -25,6 +25,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Alte
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterTableContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterSequenceContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterDomainContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.AlterProcedureContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CheckConstraintDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ColumnDefinitionContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ConstraintDefinitionContext;
@@ -58,13 +59,14 @@ import org.apache.shardingsphere.sql.parser.sql.common.value.collection.Collecti
 import org.apache.shardingsphere.sql.parser.sql.common.value.identifier.IdentifierValue;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterDomainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterSequenceStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterProcedureStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateTableStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateFunctionStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateProcedureStatement;
-import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdAlterSequenceStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateCollationStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateDomainStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
 import java.util.Collections;
@@ -247,7 +249,11 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
     public ASTNode visitCreateProcedure(final CreateProcedureContext ctx) {
         return new FirebirdCreateProcedureStatement();
     }
-      
+
+    @Override
+    public ASTNode visitAlterProcedure(final AlterProcedureContext ctx) {
+        return new FirebirdAlterProcedureStatement();
+    }
     public ASTNode visitAlterSequence(final AlterSequenceContext ctx) {
         FirebirdAlterSequenceStatement result = new FirebirdAlterSequenceStatement();
         result.setSequenceName(((SimpleTableSegment) visit(ctx.tableName())).getTableName().getIdentifier().getValue());

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdAlterProcedureStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdAlterProcedureStatement.java
@@ -15,36 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.AlterProcedureStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createFunction
-    | createProcedure
-    | createOrAlterProcedure
-    | alterProcedure
-    | alterSequence
-    | createCollation
-    | createDomain
-    | alterDomain
-    | createRole
-    | savepoint
-    ) SEMI_?
-    ;
+/**
+ * Firebird alter procedure statement.
+ */
+public final class FirebirdAlterProcedureStatement extends AlterProcedureStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #93.

***request:*** CREATE OR ALTER PROCEDURE SUMM (A INTEGER, B INTEGER) RETURNS(C INTEGER) AS BEGIN c = a + b; SUSPEND; END

***error message:*** You have an error in your SQL syntax: CREATE OR ALTER PROCEDURE SUMM (A INTEGER B INTEGER) RETURNS(C INTEGER) AS BEGIN c = a + b; SUSPEND; END no viable alternative at input 'CREATEOR' at line 1 position 8 near @18:9='OR'<99>1:8

***NEW err message:***
Can not accept SQL type `CreateOrAlterProcedureContext`.

