### PR TITLE
F671 Subqueries in CHECK constraints

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -214,7 +214,8 @@ comparisonOperator
     ;
 
 predicate
-    : bitExpr NOT? IN subquery
+    : bitExpr comparisonOperator bitExpr
+    | bitExpr NOT? IN subquery
     | bitExpr NOT? IN LP_ expr (COMMA_ expr)* RP_
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?


### PR DESCRIPTION
Fixes #95.

***request:*** CREATE DOMAIN F671 AS INTEGER CHECK(VALUE > 1000)

***err message:***  You have an error in your SQL syntax: CREATE DOMAIN F671 AS INTEGER CHECK(VALUE > 1000) no viable alternative at input 'VALUE>' at line 1 position 43 near @843:43='>'<24>1:43