### PR TITLE
F860/T152 Add EXECUTE STATEMENT support

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -100,6 +100,10 @@ tableName
     : (owner DOT_)? name
     ;
 
+variableName
+    : identifier
+    ;
+
 collationName
     : identifier
     ;
@@ -219,6 +223,8 @@ predicate
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?
     | bitExpr NOT? STARTING WITH? bitExpr
+    | bitExpr IS NOT? DISTINCT FROM bitExpr
+    | bitExpr IS NOT? NULL
     | bitExpr
     ;
 
@@ -430,6 +436,10 @@ announcementArgument
     : argumentName typeDescriptionArgument (NOT NULL)? collateClause?
     ;
 
+announcementArgumentClause
+    : announcementArgument (COMMA_ announcementArgument)*
+    ;
+
 typeDescriptionArgument
     : dataType
     | (TYPE OF)? domainName
@@ -485,3 +495,4 @@ sortOrder
     | WIN1257 | WIN1257_EE | WIN1257_LT | WIN1257_LV
     | WIN1258
     ;
+

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -347,3 +347,15 @@ createProcedure
             END
         )
     ;
+
+executeStmt
+    : EXECUTE PROCEDURE procedureName exprClause?
+    ;
+
+exprClause
+    : LP_ expr (COMMA_ expr)* RP_
+    ;
+
+returningValuesClause
+    : RETURNING_VALUES exprClause? SEMI_
+    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -127,7 +127,7 @@ createFunction
 
 
 statementBlock
-    : (statement SEMI_)*
+    : (statement SEMI_?)*
     ;
 
 statement
@@ -137,6 +137,7 @@ statement
     | delete
     | returnStatement
     | cursorOpenStatement
+    | ifStatement
     ;
 
 cursorOpenStatement
@@ -349,6 +350,10 @@ createProcedure
     ;
 
 executeStmt
+    : executeProcedure | executeBlock
+    ;
+
+executeProcedure
     : EXECUTE PROCEDURE procedureName exprClause?
     ;
 
@@ -358,4 +363,46 @@ exprClause
 
 returningValuesClause
     : RETURNING_VALUES exprClause? SEMI_
+    ;
+
+executeBlock
+    : EXECUTE BLOCK
+    inputArgumentList?
+    (RETURNS LP_ outputArgumentList RP_)?
+    AS
+        announcementClause?
+    BEGIN
+        statementBlock
+    END SEMI_
+    ;
+
+inputArgumentList
+    : LP_ announcementArgument EQ_ QUESTION_  (COMMA_ (announcementArgument EQ_ QUESTION_))* RP_
+    ;
+
+outputArgumentList
+    : announcementArgumentClause
+    ;
+
+ifStatement
+    :
+     IF LP_ predicate RP_
+     THEN beginStatement+
+     (ELSE beginStatement+)?
+    ;
+
+compoundStatement
+    : (createTable | alterTable | dropTable | dropDatabase | insert | update | delete | select | createView | beginStatement | transferOperator | assignmentStatement) SEMI_?
+    ;
+
+beginStatement
+    : BEGIN compoundStatement* END SEMI_?
+    ;
+
+transferOperator
+    : SUSPEND
+    ;
+
+assignmentStatement
+    : variableName EQ_ simpleExpr
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -855,6 +855,10 @@ STARTING
     : S T A R T I N G
     ;
 
+RETURNING_VALUES
+    : R E T U R N I N G UL_ V A L U E S
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -859,6 +859,14 @@ RETURNING_VALUES
     : R E T U R N I N G UL_ V A L U E S
     ;
 
+BLOCK
+    : B L O C K
+    ;
+
+SUSPEND
+    : S U S P E N D
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -42,6 +42,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Crea
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateCollationContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateDomainContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateSequenceContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ExecuteStmtContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.column.ColumnDefinitionSegment;
@@ -67,6 +68,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.F
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateCollationStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateDomainStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateSequenceStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdExecuteStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
 import java.util.Collections;
@@ -271,5 +273,10 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
         FirebirdCreateSequenceStatement result = new FirebirdCreateSequenceStatement();
         result.setSequenceName(((SimpleTableSegment) visit(ctx.tableName())).getTableName().getIdentifier().getValue());
         return result;
+    }
+
+    @Override
+    public ASTNode visitExecuteStmt(final ExecuteStmtContext ctx) {
+        return new FirebirdExecuteStatement();
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdExecuteStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdExecuteStatement.java
@@ -15,36 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.ExecuteStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createFunction
-    | createProcedure
-    | alterSequence
-    | createCollation
-    | createDomain
-    | alterDomain
-    | createRole
-    | savepoint
-    | createSequence
-    | executeStmt
-    ) SEMI_?
-    ;
+/**
+ * PostgreSQL execute statement.
+ */
+public final class FirebirdExecuteStatement extends ExecuteStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #97, #42.

1. request:
EXECUTE PROCEDURE F860_PROC(0,3)
* err message: 
You have an error in your SQL syntax: EXECUTE PROCEDURE F860_PROC(03) no viable alternative at input 'EXECUTE' at line 1 position 1 near @01:7='EXECUTE'<265>1:1

2. request: 
EXECUTE block RETURNS (s VARCHAR(100)) AS BEGIN IF (NULL IS NOT DISTINCT FROM NULL) THEN BEGIN s = 'null is not distinct from null'; suspend; END END;
* err message: 
You have an error in your SQL syntax: EXECUTE block RETURNS (s VARCHAR(100)) AS BEGIN IF (NULL IS NOT DISTINCT FROM NULL) THEN BEGIN s = 'null is not distinct from null'; suspend; END END; null
