### PR TITLE
F312 Add grammar support for MERGE

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -149,6 +149,10 @@ baseSortName
     : identifier
     ;
 
+variableName
+    : identifier
+    ;
+
 constraintName
     : identifier
     ;
@@ -214,7 +218,8 @@ comparisonOperator
     ;
 
 predicate
-    : bitExpr NOT? IN subquery
+    : bitExpr comparisonOperator bitExpr
+    | bitExpr NOT? IN subquery
     | bitExpr NOT? IN LP_ expr (COMMA_ expr)* RP_
     | bitExpr NOT? BETWEEN bitExpr AND predicate
     | bitExpr NOT? LIKE simpleExpr (ESCAPE simpleExpr)?

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -190,3 +190,45 @@ withClause
 cteClause
     : identifier (LP_ columnNames RP_)? AS subquery
     ;
+
+merge
+    : MERGE intoClause usingClause
+    mergeWhen (mergeWhen)*
+    (RETURNING returnExprListClause (INTO variableListClause)?)?
+    ;
+
+intoClause
+    : INTO (tableName | viewName | subquery) (AS? alias)?
+    ;
+
+usingClause
+    : USING ((tableName | viewName) | subquery) (AS? alias)? ON predicate
+    ;
+
+mergeWhen
+    : mergeWhenMatched | mergeWhenNotMatched
+    ;
+
+mergeWhenMatched
+    : WHEN MATCHED (AND predicate)? THEN (UPDATE SET columnName EQ_ expr (COMMA_ (columnName EQ_ expr))* | DELETE )
+    ;
+
+mergeWhenNotMatched
+    : WHEN NOT MATCHED (AND predicate)? THEN INSERT columnNames? VALUES LP_ expr RP_
+    ;
+
+returnExpr
+    : expr (AS? alias)
+    ;
+
+returnExprListClause
+    : returnExpr (COMMA_ returnExpr)*
+    ;
+
+variableList
+    : LBT_ COLON_ RBT_ variableName
+    ;
+
+variableListClause
+    : variableList (COMMA_ variableList)*
+    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -855,6 +855,18 @@ STARTING
     : S T A R T I N G
     ;
 
+MERGE
+    : M E R G E
+    ;
+
+RETURNING
+    : R E T U R N I N G
+    ;
+
+MATCHED
+    : M A T C H E D
+    ;
+
 //PASSWORD
 //    : P A S S W O R D
 //    ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDMLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDMLStatementVisitor.java
@@ -52,6 +52,9 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Tabl
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.TableReferencesContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.UpdateContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.WhereClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.MergeContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.IntoClauseContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.UsingClauseContext;
 import org.apache.shardingsphere.sql.parser.sql.common.enums.JoinType;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.AssignmentSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.dml.assignment.ColumnAssignmentSegment;
@@ -92,6 +95,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml.F
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml.FirebirdInsertStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml.FirebirdSelectStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml.FirebirdUpdateStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml.FirebirdMergeStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
 import java.util.Collection;
@@ -478,5 +482,15 @@ public final class FirebirdDMLStatementVisitor extends FirebirdStatementVisitor 
     @Override
     public ASTNode visitSubquery(final SubqueryContext ctx) {
         return visit(ctx.combineClause());
+    }
+
+    @Override
+    public ASTNode visitMerge(final MergeContext ctx) {
+        FirebirdMergeStatement result = new FirebirdMergeStatement();
+        result.setTarget((TableSegment) visit(ctx.intoClause()));
+        result.setSource((TableSegment) visit(ctx.usingClause()));
+        // add mergeWhenNotMatched and mergeWhenMatched part
+        // add RETURNING part
+        return result;
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/dml/FirebirdMergeStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/dml/FirebirdMergeStatement.java
@@ -15,36 +15,13 @@
  * limitations under the License.
  */
 
-grammar FirebirdStatement;
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.dml;
 
-import Comments, DDLStatement, TCLStatement, DCLStatement;
+import org.apache.shardingsphere.sql.parser.sql.common.statement.dml.MergeStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
 
-execute
-    : (select
-    | insert
-    | update
-    | delete
-    | createDatabase
-    | dropDatabase
-    | createTable
-    | alterTable
-    | dropTable
-    | createView
-    | dropView
-    | setTransaction
-    | commit
-    | rollback
-    | grant
-    | revoke
-    | createFunction
-    | createProcedure
-    | alterSequence
-    | createCollation
-    | createDomain
-    | alterDomain
-    | createRole
-    | savepoint
-    | createSequence
-    | merge
-    ) SEMI_?
-    ;
+/**
+ * Firebird merge statement.
+ */
+public final class FirebirdMergeStatement extends MergeStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #28.

request: MERGE INTO CUSTOMER USING ( SELECT AGENT_CODE FROM AGENTS WHERE AGENT_CODE = 'A006') AG ON CUSTOMER.AGENT_CODE = AG.AGENT_CODE WHEN MATCHED THEN DELETE
err message: You have an error in your SQL syntax: MERGE INTO agents a USING (SELECT * FROM agents WHERE commission > 0.15) cd ON (a.agent_code = cd.agent_code) WHEN MATCHED THEN UPDATE SET agent_code = cd.agent_code WHEN NOT MATCHED THEN INSERT (agent_code) VALUES (cd.agent_code) no viable alternative at input 'MERGE' at line 1 position 1 near @01:5='MERGE'<340>1:1

***new err message:***
class org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment cannot be cast to class org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment (org.apache.shardingsphere.sql.parser.sql.common.segment.generic.AliasSegment and org.apache.shardingsphere.sql.parser.sql.common.segment.generic.table.TableSegment are in unnamed module of loader 'app')
