### PR TITLE
T211 Basic trigger capability

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -97,7 +97,7 @@ savepointName
     ;
 
 variableName
-    : identifier
+    : (owner DOT_)? name
     ;
 
 domainName


### PR DESCRIPTION
Fixes #102.

request: CREATE OR ALTER trigger company_bi1 for company active before insert position 0 AS begin if (new.typeproduct = 'PC') then begin new.typeproduct = 'pc'; end end

err message: You have an error in your SQL syntax: CREATE OR ALTER trigger company_bi1 for company active before insert position 0 AS begin if (new.typeproduct = 'PC') then begin new.typeproduct = 'pc'; end end null