### PR TITLE
F852 Top-level 'order by clause' in views

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -202,9 +202,18 @@ dropDatabase
     ;
 
 createView
-    : CREATE VIEW viewName (LP_ identifier (COMMA_ identifier)* RP_)?
+    : (CREATE VIEW | CREATE OR ALTER VIEW)
+    viewName viewAliasClause?
       AS select
       (WITH (CASCADED | LOCAL)? CHECK OPTION)?
+    ;
+
+viewAliasClause
+    : LP_ viewAlias (COMMA_ viewAlias)* RP_
+    ;
+
+viewAlias
+    : columnName (AS alias)?
     ;
 
 dropView


### PR DESCRIPTION
Fixes #108.

request: CREATE OR ALTER VIEW F852(ID, namecompany) AS SELECT id, namecompany FROM company ORDER BY typeproduct

err message: 
You have an error in your SQL syntax: CREATE OR ALTER VIEW F852(ID namecompany) AS SELECT id namecompany FROM company ORDER BY typeproduct no viable alternative at input 'CREATEORALTERVIEW' at line 1 position 17 near @317:20='VIEW'<69>1:17

new err message:

class org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.OrderBySegment cannot be cast to class org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement (org.apache.shardingsphere.sql.parser.sql.common.segment.dml.order.OrderBySegment and org.apache.shardingsphere.sql.parser.sql.common.statement.SQLStatement are in unnamed module of loader 'app')