### PR TITLE
T211 Basic trigger capability

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -386,15 +386,11 @@ returningValuesClause
     ;
 
 createTrigger
-    : CREATE TRIGGER triggerName triggerClause
+    : (CREATE TRIGGER | CREATE OR ALTER TRIGGER) triggerName triggerClause
     ;
 
 alterTrigger
     : ALTER TRIGGER triggerName (ACTIVE | INACTIVE)? ((BEFORE | AFTER) eventListTable)? (POSITION expr)? triggerClause
-    ;
-
-createOrAlterTrigger
-    : CREATE OR ALTER TRIGGER triggerName triggerClause
     ;
 
 announcmentTriggerClause
@@ -535,7 +531,7 @@ ifStatement
     ;
 
 compoundStatement
-    : (createTable | alterTable | dropTable | dropDatabase | insert | update | delete | select | createView | beginStatement | ifStatement | fetchStatement | leaveStatement | transferStatement | cursorCloseStatement) SEMI_?
+    : (createTable | alterTable | dropTable | dropDatabase | insert | update | delete | select | createView | beginStatement | ifStatement | fetchStatement | leaveStatement | transferStatement | cursorCloseStatement | assignmentStatement) SEMI_?
     ;
 
 beginStatement

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -386,7 +386,7 @@ returningValuesClause
     ;
 
 createTrigger
-    : (CREATE TRIGGER | CREATE OR ALTER TRIGGER) triggerName triggerClause
+    : (CREATE (OR ALTER)? TRIGGER) triggerName triggerClause
     ;
 
 alterTrigger

--- a/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
@@ -44,7 +44,6 @@ execute
     | alterDomain
     | createRole
     | savepoint
-    | createOrAlterTrigger
     | createTrigger
     | alterTrigger
     | executeBlock


### PR DESCRIPTION
Fixes #110.

request: CREATE OR ALTER trigger company_bi1 for company active before insert position 0 AS begin if (new.typeproduct = 'PC') then begin new.typeproduct = 'pc'; end end

err message: You have an error in your SQL syntax: CREATE OR ALTER trigger company_bi1 for company active before insert position 0 AS begin if (new.typeproduct = 'PC') then begin new.typeproduct = 'pc'; end end null
