### PR TITLE
T321 CREATE OR ALTER PROCEDURE

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -342,7 +342,7 @@ returnStatement
     ;
 
 createProcedure
-    : (CREATE PROCEDURE | CREATE OR ALTER PROCEDURE) procedureClause
+    : (CREATE (OR ALTER)? PROCEDURE) procedureClause
     ;
 
 alterProcedure

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -342,11 +342,7 @@ returnStatement
     ;
 
 createProcedure
-    : CREATE PROCEDURE procedureClause
-    ;
-
-createOrAlterProcedure
-    : CREATE OR ALTER PROCEDURE procedureClause
+    : (CREATE PROCEDURE | CREATE OR ALTER PROCEDURE) procedureClause
     ;
 
 alterProcedure


### PR DESCRIPTION
Fixes #113.

request: CREATE OR ALTER PROCEDURE SUMM (A INTEGER, B INTEGER) RETURNS(C INTEGER) AS BEGIN c = a + b; SUSPEND; END

err message: Can not accept SQL type `CreateOrAlterProcedureContext`.

