### PR TITLE
F031 Add COMMENT support 

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -108,6 +108,14 @@ tableName
     : (owner DOT_)? name
     ;
 
+packageName
+    : identifier
+    ;
+
+parameterName
+    : identifier
+    ;
+
 collationName
     : identifier
     ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -546,3 +546,29 @@ leaveStatement
     : LEAVE expr? SEMI_
     ;
 
+comment
+    : COMMENT ON (
+      DATABASE
+    | baseTypeComment tableName
+    | COLUMN tableName.columnName
+    | (PROCEDURE | FUNCTION) PARAMETER (packageName DOT_)? procedureName DOT_ parameterName
+    | (PROCEDURE | EXTERNAL? FUNCTION) (packageName DOT_)? procedureName
+    ) IS (STRING_ | NULL)
+    ;
+
+baseTypeComment
+    : CHARACTER SET
+    | COLLATION
+    | DOMAIN
+    | EXCEPTION
+    | FILTER
+    | GENERATOR
+    | INDEX
+    | PACKAGE
+    | USER
+    | ROLE
+    | SEQUENCE
+    | TABLE
+    | TRIGGER
+    | VIEW
+    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -958,3 +958,19 @@ WHILE
 LEAVE
     : L E A V E
     ;
+
+FILTER
+    : F I L T E R
+    ;
+
+PARAMETER
+    : P A R A M E T E R
+    ;
+
+DATABASE
+    : D A T A B A S E
+    ;
+
+COMMENT
+    : C O M M E N T
+    ;

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/Symbol.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/Symbol.g4
@@ -56,4 +56,4 @@ SQ_ :                '\'';
 QUESTION_:           '?';
 AT_:                 '@';
 SEMI_:               ';';
-COMMENT:             '--';
+COMMENT_:             '--';

--- a/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/org/apache/shardingsphere/sql/parser/autogen/FirebirdStatement.g4
@@ -52,5 +52,6 @@ execute
     | merge
     | createUser
     | executeStmt
+    | comment
     ) SEMI_? EOF
     ;

--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -45,6 +45,7 @@ import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.Crea
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateDomainContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateTriggerContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CreateSequenceContext;
+import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.CommentContext;
 import org.apache.shardingsphere.sql.parser.autogen.FirebirdStatementParser.ExecuteStmtContext;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.AlterDefinitionSegment;
 import org.apache.shardingsphere.sql.parser.sql.common.segment.ddl.CreateDefinitionSegment;
@@ -74,6 +75,7 @@ import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.F
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateTriggerStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdDropTableStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCreateSequenceStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdCommentStatement;
 import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl.FirebirdExecuteStatement;
 import org.apache.shardingsphere.sql.parser.firebird.visitor.statement.FirebirdStatementVisitor;
 
@@ -300,5 +302,17 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
     @Override
     public ASTNode visitExecuteStmt(final ExecuteStmtContext ctx) {
         return new FirebirdExecuteStatement();
+    }
+
+    @Override
+    public ASTNode visitComment(final CommentContext ctx) {
+        FirebirdCommentStatement result = new FirebirdCommentStatement();
+        if (null != ctx.tableName()) {
+            result.setTable((SimpleTableSegment) visit(ctx.tableName()));
+        }
+        if (null != ctx.columnName()) {
+            result.setColumn((ColumnSegment) visit(ctx.columnName()));
+        }
+        return result;
     }
 }

--- a/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCommentStatement.java
+++ b/parser/sql/statement/src/main/java/org/apache/shardingsphere/sql/parser/sql/dialect/statement/firebird/ddl/FirebirdCommentStatement.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.ddl;
+
+import org.apache.shardingsphere.sql.parser.sql.common.statement.ddl.CommentStatement;
+import org.apache.shardingsphere.sql.parser.sql.dialect.statement.firebird.FirebirdStatement;
+
+/**
+ * Firebird comment statement.
+ */
+public final class FirebirdCommentStatement extends CommentStatement implements FirebirdStatement {
+}


### PR DESCRIPTION
Fixes #17

request: COMMENT ON TABLE F31_01 IS 'F31-01 CREATE TABLE statement'
err message: You have an error in your SQL syntax: COMMENT ON TABLE F31_01 IS 'F31-01 CREATE TABLE statement' no viable alternative at input 'COMMENT' at line 1 position 1 near @01:7='COMMENT'<340>1:1