### PR TITLE
F381 Correct Drop Constraint Support

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -272,7 +272,7 @@ usingDefinition
     ;
 
 constraintDefinition
-    : (CONSTRAINT constraintName?)? (primaryKeyOption | uniqueOption | foreignKeyOption)
+    : (CONSTRAINT constraintName?)? (primaryKeyOption | uniqueOption | foreignKeyOption)?
     ;
 
 primaryKeyOption


### PR DESCRIPTION
Fixes #29.
request: ALTER TABLE F381_021 DROP CONSTRAINT FK_381_ROW_ID
err message: You have an error in your SQL syntax: no viable alternative at input ''

