### PR TITLE
F861 Top-level 'result offset clause' in 'query expression' 

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DMLStatement.g4
@@ -73,7 +73,7 @@ combineClause
     ;
 
 selectClause
-    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause?
+    : SELECT selectSpecification* projections fromClause? whereClause? groupByClause? havingClause? orderByClause? limitClause?
     ;
 
 


### PR DESCRIPTION
Fixes #128.

request: SELECT term,user_name,score FROM F855 OFFSET 3 ROWS

error message: You have an error in your SQL syntax: SELECT termuser_namescore FROM F855 OFFSET 3 ROWS null
