### PR TITLE
F431 FETCH

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -348,7 +348,7 @@ returnStatement
     ;
 
 createProcedure
-    : (CREATE (OR ALTER)? PROCEDURE) procedureClause
+    : (CREATE PROCEDURE | CREATE OR ALTER PROCEDURE) procedureClause
     ;
 
 alterProcedure
@@ -517,13 +517,13 @@ whileStatement
 
 fetchStatement
     : FETCH cursorName
-    INTO COLON_ variable (COMMA_ (COLON_ variable))* SEMI_
+    (INTO COLON_ variable (COMMA_ (COLON_ variable))* SEMI_)?
     | FETCH (NEXT
              | PRIOR
              | FIRST
              | LAST
              | ABSOLUTE NUMBER_
-             | RELATIVE NUMBER_ ) FROM cursorName (INTO LBT_ COLON_ RBT_ variable (COMMA_ (LBT_ COLON_ RBT_ variable))* SEMI_)
+             | RELATIVE NUMBER_ ) FROM cursorName (INTO LBT_ COLON_ RBT_ variable (COMMA_ (LBT_ COLON_ RBT_ variable))* SEMI_)?
     ;
 
 ifStatement


### PR DESCRIPTION
Fixes #132.

request: CREATE OR ALTER PROCEDURE GET_NAMECOMPANY4 RETURNS (NAMECOM CHAR(30)) AS DECLARE curs1 CURSOR FOR (Select namecompany from Company where typeproduct = 'pc'); BEGIN OPEN curs1; FETCH NEXT FROM curs1; NAMECOM = curs1.namecompany; SUSPEND; CLOSE curs1; END

error message: You have an error in your SQL syntax: CREATE OR ALTER PROCEDURE GET_NAMECOMPANY4 RETURNS (NAMECOM CHAR(30)) AS DECLARE curs1 CURSOR FOR (Select namecompany from Company where typeproduct = 'pc'); BEGIN OPEN curs1; FETCH NEXT FROM curs1; NAMECOM = curs1.namecompany; SUSPEND; CLOSE curs1; END null