### PR TITLE
T141 SIMILAR predicate support 

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -112,10 +112,6 @@ tableName
     : (owner DOT_)? name
     ;
 
-packageName
-    : identifier
-    ;
-
 parameterName
     : identifier
     ;
@@ -254,6 +250,7 @@ predicate
     | bitExpr NOT? STARTING WITH? bitExpr
     | bitExpr IS NOT? DISTINCT FROM bitExpr
     | bitExpr IS NOT? NULL
+    | bitExpr NOT? SIMILAR TO bitExpr (ESCAPE bitExpr)?
     | bitExpr
     ;
 

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/DDLStatement.g4
@@ -262,7 +262,7 @@ dataTypeOption
     ;
 
 checkConstraintDefinition
-    : (CONSTRAINT ignoredIdentifier?)? CHECK expr
+    : (CONSTRAINT ignoredIdentifier?)? checkClause
     ;
 
 referenceDefinition

--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/FirebirdKeyword.g4
@@ -974,3 +974,7 @@ DATABASE
 COMMENT
     : C O M M E N T
     ;
+
+SIMILAR
+    : S I M I L A R
+    ;


### PR DESCRIPTION
Fixes #41.

req: CREATE TABLE T141 (ROW_NUM NUMERIC(3) NOT NULL, ROW_NAME VARCHAR(25) NOT NULL, ROW_PHONE VARCHAR(14) CHECK (ROW_PHONE SIMILAR TO '\([0-9]{3}\) [0-9]{3}\-[0-9]{4}' escape '\'))

err: You have an error in your SQL syntax: CREATE TABLE T141 (ROW_NUM NUMERIC(3) NOT NULL ROW_NAME VARCHAR(25) NOT NULL ROW_PHONE VARCHAR(14) CHECK (ROW_PHONE SIMILAR TO '(0-9{3}) 0-9{3}-0-9{4}' escape '')) no viable alternative at input '(ROW_PHONESIMILAR' at line 1 position 119 near @28119:125='SIMILAR'<340>1:119

***new err:***
You have an error in your SQL syntax: no viable alternative at input '''

Error with part: " escape '\\' "