### PR TITLE
S091 Basic array support

### DIFF
--- a/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
+++ b/parser/sql/dialect/firebird/src/main/antlr4/imports/firebird/BaseRule.g4
@@ -421,7 +421,9 @@ limitOffset
     ;
 
 dataType
-    : dataTypeName dataTypeLength? characterSet? collateClause? | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
+    : dataTypeName dataTypeLength? characterSet? collateClause?
+    | dataTypeName LP_ STRING_ (COMMA_ STRING_)* RP_ characterSet? collateClause?
+    | dataTypeName LBT_ (NUMBER_? COLON_ NUMBER | NUMBER_ (COMMA_ NUMBER_)*) RBT_
     ;
 
 dataTypeName


### PR DESCRIPTION
Fixes #37.

request: CREATE TABLE S091_01 (ARR_INT2 INTEGER[4,5], ARR_INT3 INTEGER[4,5,6], ARR_INT6 INTEGER[4,5,6,7])
err message: You have an error in your SQL syntax: CREATE TABLE S091_01 (ARR_INT2 INTEGER45 ARR_INT3 INTEGER456 ARR_INT6 INTEGER4567) null

New Err message: Types.ARRAY: SQL type for this field is not yet supported.

