### PR TITLE
CREATE TABLE with empty datatype

### DIFF
--- a/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
+++ b/parser/sql/dialect/firebird/src/main/java/org/apache/shardingsphere/sql/parser/firebird/visitor/statement/type/FirebirdDDLStatementVisitor.java
@@ -124,9 +124,8 @@ public final class FirebirdDDLStatementVisitor extends FirebirdStatementVisitor 
     @Override
     public ASTNode visitColumnDefinition(final ColumnDefinitionContext ctx) {
         ColumnSegment column = (ColumnSegment) visit(ctx.columnName());
-        DataTypeSegment dataType = (DataTypeSegment) visit(ctx.dataType());
+        DataTypeSegment dataType = ctx.dataType() != null ? (DataTypeSegment) visit(ctx.dataType()) : null;
         boolean isPrimaryKey = ctx.dataTypeOption().stream().anyMatch(each -> null != each.primaryKey());
-        // TODO parse not null
         ColumnDefinitionSegment result = new ColumnDefinitionSegment(ctx.getStart().getStartIndex(), ctx.getStop().getStopIndex(), column, dataType, isPrimaryKey, false);
         for (DataTypeOptionContext each : ctx.dataTypeOption()) {
             if (null != each.referenceDefinition()) {


### PR DESCRIPTION
Fixes #59.

request: CREATE TABLE T175 (row_a int, row_b generated always as (3*row_a))

err mess: Cannot invoke "org.antlr.v4.runtime.tree.ParseTree.accept(org.antlr.v4.runtime.tree.ParseTreeVisitor)" because "tree" is null