### PR TITLE
Added Firebird support to the SQL parser test utility.

### DIFF
--- a/parser/sql/dialect/firebird/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/firebird/internal/InternalFirebirdParserIT.java
+++ b/parser/sql/dialect/firebird/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/firebird/internal/InternalFirebirdParserIT.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.it.firebird.internal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.InternalSQLParserIT;
+import org.apache.shardingsphere.test.it.sql.parser.internal.InternalSQLParserITSettings;
+
+@InternalSQLParserITSettings("Firebird")
+class InternalFirebirdParserIT extends InternalSQLParserIT {
+}

--- a/parser/sql/dialect/firebird/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/firebird/internal/InternalUnsupportedFirebirdParserIT.java
+++ b/parser/sql/dialect/firebird/src/test/java/org/apache/shardingsphere/test/it/sql/parser/it/firebird/internal/InternalUnsupportedFirebirdParserIT.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.shardingsphere.test.it.sql.parser.it.firebird.internal;
+
+import org.apache.shardingsphere.test.it.sql.parser.internal.InternalSQLParserITSettings;
+import org.apache.shardingsphere.test.it.sql.parser.internal.InternalUnsupportedSQLParserIT;
+
+@InternalSQLParserITSettings("Firebird")
+class InternalUnsupportedFirebirdParserIT extends InternalUnsupportedSQLParserIT {
+}

--- a/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/SQLCases.java
+++ b/test/it/parser/src/main/java/org/apache/shardingsphere/test/it/sql/parser/internal/cases/sql/SQLCases.java
@@ -76,7 +76,7 @@ public final class SQLCases {
     }
     
     private Collection<String> getAllDatabaseTypes() {
-        return Arrays.asList("H2", "MySQL", "PostgreSQL", "Oracle", "SQLServer", "SQL92", "openGauss");
+        return Arrays.asList("H2", "MySQL", "PostgreSQL", "Oracle", "SQLServer", "SQL92", "openGauss", "Firebird");
     }
     
     private boolean containsSQLCaseType(final SQLCase sqlCase, final SQLCaseType caseType) {


### PR DESCRIPTION
Fixes #8.

Added a framework for further development. Removed other changes, leaving only the foundation to manage modifications in future commits.
